### PR TITLE
Adding dark mode support

### DIFF
--- a/build-content.js
+++ b/build-content.js
@@ -3,7 +3,7 @@ import * as cheerio from "cheerio";
 import { promises as fs } from "fs";
 import { getHighlighter } from "shiki";
 
-const THEME = "github-light";
+const THEME = "github-dark";
 
 const shiki = await getHighlighter({
   theme: THEME,

--- a/src/app.css
+++ b/src/app.css
@@ -23,6 +23,14 @@
   --spacing: 0.5rem;
 }
 
+@media (prefers-color-scheme: dark) {
+  :root {
+    --gray-bg: #343434;
+    --gray-border: #7d8590;
+    --orange: #ff3e00;
+  }
+}
+
 @media (min-width: 640px) {
   :root {
     --text-base: 19px;
@@ -33,6 +41,7 @@
 
 html {
   font-size: var(--baseline);
+  color-scheme: dark light;
 }
 
 body {
@@ -75,7 +84,6 @@ kbd {
 pre,
 code:not(pre > code),
 kbd {
-  background-color: var(--gray-bg) !important;
   border: 1px solid var(--gray-border);
   border-radius: 2px;
   padding: 0 0.2em;
@@ -89,6 +97,7 @@ pre {
 
 code:not(pre > code),
 kbd {
+  background-color: var(--gray-bg) !important;
   font-size: var(--text-inline-code);
   white-space: nowrap;
 }


### PR DESCRIPTION
Hey there, really like the idea of your site, since it's inspired by the gobyexample site, which i also really like.

I've checked and there is no dark mode, so i decided to make one, but there is a major change, even in light mode, the code snippet still going to have a dark theme, mostly because of how the shiki highlighter works. It does offer a way of supporting both light and dark mode, but I've found the [solutions](https://github.com/shikijs/shiki/blob/main/docs/themes.md#dark-mode-support) to be a little clunky, idk.

Anyways
-  Light mode:
![sveltebyexample-light](https://github.com/sebastiandedeyne/sveltebyexample.com/assets/92128913/c4702781-5750-4a09-a41a-e462aadd193c)

-  Dark mode:
![sveltebyexample-dark](https://github.com/sebastiandedeyne/sveltebyexample.com/assets/92128913/71d3d2db-c0e3-4b64-ada9-c3677e8d0e25)

