### PR TITLE
Fix 'Readable Stores.md' file

### DIFF
--- a/content/21. Readable Stores.md
+++ b/content/21. Readable Stores.md
@@ -4,7 +4,7 @@ A readable store is a store that can be subscribed to, but not updated from a co
 
 ---
 
-{2} Svelte exposes a `readable` function to create writable stores.
+{2} Svelte exposes a `readable` function to create readable stores.
 
 {7} Readable accepts two arguments. The first is the default value for the store. The second a start function to keep the value up to date.
 
@@ -59,4 +59,4 @@ export const theme = readable(
 ## Resources
 
 - [Svelte Tutorial: Readable Stores](https://learn.svelte.dev/tutorial/readable-stores)
-- [Svelte Docs: svelte/store](https://svelte.dev/docs/svelte-store#writable)
+- [Svelte Docs: svelte/store](https://svelte.dev/docs/svelte-store#readable)


### PR DESCRIPTION
The text erroneously mentions "writable stores", where it should say "readable stores" and also links to the "#writable" anchor where it should link to "#readable" instead.